### PR TITLE
fix en horas

### DIFF
--- a/client/src/Components/Court/AvailabilityForm/helpers/functions.js
+++ b/client/src/Components/Court/AvailabilityForm/helpers/functions.js
@@ -50,8 +50,8 @@ export const splitHours = (array) => {
             newArray.push(obj)
         }
         else if(difference > 1) {
-            let start = Number(obj.start.slice(0, 2))
-            let end = Number(obj.start.slice(3))
+            let start = Number(obj.start.split(":")[0])
+            let end = obj.start.split(":")[1] == "0" ? "00" : obj.start.split(":")[1]
             for (let i = 0; i < difference; i++) {
                 let obj = {
                     start: `${start}:${end}`,


### PR DESCRIPTION
Arreglé un bug en Horarios.
Si no escribías el 00 en "13:00", por ejemplo, te seteaba la hora como "13:0".